### PR TITLE
Enable custom autosave configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ DIRS += $(wildcard *Sup)
 DIRS += $(wildcard *App)
 DIRS += $(wildcard *Top)
 DIRS += $(wildcard iocBoot)
+DIRS += postinstall
 
 # The build order is controlled by these dependency rules:
 
@@ -25,6 +26,7 @@ $(foreach dir, $(filter %Top, $(DIRS)), \
 
 # iocBoot depends on all *App dirs
 iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+postinstall_DEPEND_DIRS += iocBoot $(wildcard *App)
 
 # Add any additional dependency rules here:
 

--- a/iocBoot/iocCamera/autosave.cmd
+++ b/iocBoot/iocCamera/autosave.cmd
@@ -15,6 +15,7 @@ set_pass0_restoreFile("$(PREFIX).sav")
 set_pass1_restoreFile("$(PREFIX).sav")
 
 set_requestfile_path(".")
+set_requestfile_path("./genicam")
 set_requestfile_path("./basler")
 set_requestfile_path("$(TOP)", "CameraApp/Db")
 set_requestfile_path("$(CALC)", "calcApp/Db")

--- a/iocBoot/iocCamera/device.cmd
+++ b/iocBoot/iocCamera/device.cmd
@@ -48,6 +48,3 @@ dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(PREFIX)")
 
 # Trace error and warning messages
 asynSetTraceMask("$(PORT)", 0, ERROR | WARNING)
-
-# Configure autosave
-< autosave.cmd

--- a/iocBoot/iocCamera/st.cmd
+++ b/iocBoot/iocCamera/st.cmd
@@ -1,4 +1,4 @@
-#!/opt/ad-aravis-epics-ioc/bin/linux-x86_64/Camera
+#!/usr/bin/env Camera
 # -*- container-image: ghcr.io/cnpem/ad-aravis-epics-ioc
 
 cd /opt/ad-aravis-epics-ioc/iocBoot/iocCamera

--- a/iocBoot/iocCamera/st.cmd
+++ b/iocBoot/iocCamera/st.cmd
@@ -1,9 +1,8 @@
 #!/usr/bin/env Camera
 # -*- container-image: ghcr.io/cnpem/ad-aravis-epics-ioc
 
-cd /opt/ad-aravis-epics-ioc/iocBoot/iocCamera
-
-< envPaths
+< /usr/local/share/misc/envPaths
+epicsEnvSet("IOC_CONFIG", "$(TOP)/iocBoot/$(IOC)")
 
 # IOC and device specific configuration
 epicsEnvSet("PREFIX", "BL:H:BASLER01:")
@@ -12,7 +11,7 @@ epicsEnvSet("DEVICE_MANUFACTURER", "Basler")
 epicsEnvSet("DEVICE_MODEL", "acA1300-75gm")
 epicsEnvSet("DEVICE_VERSION", "106755-13")
 
-< device.cmd
+< $(IOC_CONFIG)/device.cmd
 
 # Configure Area Detector plugins
 epicsEnvSet("MAX_IMAGE_WIDTH", 1280)
@@ -21,15 +20,15 @@ epicsEnvSet("MAX_IMAGE_PIXELS", 1310720)
 epicsEnvSet("QSIZE", 20)
 epicsEnvSet("QSIZE_HDF5", 50)
 
-< plugins.cmd
+< $(IOC_CONFIG)/plugins.cmd
 
 # Restrict camera features
 epicsEnvSet("ACQUIRE_PERIOD_LOW_LIMIT", 0.1)
 
-< limits.cmd
+< $(IOC_CONFIG)/limits.cmd
 
-< autosave.cmd
+< $(IOC_CONFIG)/autosave.cmd
 
 iocInit()
 
-< post-init.cmd
+< $(IOC_CONFIG)/post-init.cmd

--- a/iocBoot/iocCamera/st.cmd
+++ b/iocBoot/iocCamera/st.cmd
@@ -28,6 +28,8 @@ epicsEnvSet("ACQUIRE_PERIOD_LOW_LIMIT", 0.1)
 
 < limits.cmd
 
+< autosave.cmd
+
 iocInit()
 
 < post-init.cmd

--- a/postinstall/Makefile
+++ b/postinstall/Makefile
@@ -2,6 +2,8 @@ TOP=..
 include $(TOP)/configure/CONFIG
 
 install:
+	mkdir -p /usr/local/share/misc
+	ln -s $(shell realpath $(TOP))/iocBoot/iocCamera/envPaths /usr/local/share/misc/
 	ln -s $(shell realpath $(INSTALL_HOST_BIN))/Camera /usr/local/bin/
 
 include $(CONFIG)/RULES_DIRS

--- a/postinstall/Makefile
+++ b/postinstall/Makefile
@@ -1,0 +1,7 @@
+TOP=..
+include $(TOP)/configure/CONFIG
+
+install:
+	ln -s $(shell realpath $(INSTALL_HOST_BIN))/Camera /usr/local/bin/
+
+include $(CONFIG)/RULES_DIRS


### PR DESCRIPTION
The IOC loads autosave configuration automatically through the `device.cmd`, which makes it harder to have a personalized configuration. Moreover, using `cd` in the iocsh template makes the `set_requirefile_path` settings to be impossible to be used for local custom files, as the container volume mounted during execution is not predictable, which was the initial intention while writing, for instance, `plugins.req`.

Make this configuration possible to be overwritten by local custom files, either in the overall autosave configuration or in the specific requirement files used.