### PR TITLE
ci: use epics-in-docker IOC build workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: Build image
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  build_and_push:
+    permissions:
+      packages: write
+      contents: read
+    uses: cnpem/epics-in-docker/.github/workflows/ioc-images.yml@main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ioc:
-    image: ghcr.io/cnpem/ad-aravis-epics-ioc
+    image: ghcr.io/cnpem/ad-aravis-epics-ioc:${TAG}
     build:
       context: ./
       dockerfile: docker/Dockerfile


### PR DESCRIPTION
The workflow is configured to use Git tags to push tagged images to the registry.