### PR TITLE
plugins: define plugin queue sizes by default.

### DIFF
--- a/iocBoot/iocCamera/plugins.cmd
+++ b/iocBoot/iocCamera/plugins.cmd
@@ -8,12 +8,6 @@
 # $(PORT)
 # The port name for the detector.
 #
-# $(QSIZE)
-# The queue size for all plugins.
-#
-# $(QSIZE_HDF5)
-# Queue size for HDF5 plugin.
-#
 # $(MAX_IMAGE_WIDTH)
 # The maximum image width.
 # Used to set the maximum size for row profiles in the NDPluginStats plugin.
@@ -39,6 +33,14 @@
 # This should be consistent with IMAGE_ASYN_TYPE.
 # Defaults to USHORT.
 #
+# $(QSIZE)
+# The queue size for all plugins.
+# Defaults to 20
+#
+# $(QSIZE_HDF5)
+# Queue size for HDF5 plugin.
+# Defaults to 50
+#
 # $(NCHANS)
 # The maximum number of time series points in the NDPluginStats plugin.
 # Defaults to 2048.
@@ -48,43 +50,43 @@
 # Defaults to 4.
 
 # Create Channel Access conversion plugin
-NDStdArraysConfigure("Image1", $(QSIZE), 0, $(PORT), 0, 0, 0, 0)
+NDStdArraysConfigure("Image1", $(QSIZE=20), 0, $(PORT), 0, 0, 0, 0)
 dbLoadRecords("NDStdArrays.template", "P=$(PREFIX), R=image1:, PORT=Image1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT), TYPE=$(IMAGE_ASYN_TYPE=Int16), FTVL=$(IMAGE_WAVEFORM_TYPE=USHORT), NELEMENTS=$(MAX_IMAGE_PIXELS)")
 
 # Create 3 ROI plugins
-NDROIConfigure("ROI1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDROIConfigure("ROI1", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
 dbLoadRecords("NDROI.template", "P=$(PREFIX), R=ROI1:, PORT=ROI1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
-NDROIConfigure("ROI2", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDROIConfigure("ROI2", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
 dbLoadRecords("NDROI.template", "P=$(PREFIX), R=ROI2:, PORT=ROI2, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
-NDROIConfigure("ROI3", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDROIConfigure("ROI3", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
 dbLoadRecords("NDROI.template", "P=$(PREFIX), R=ROI3:, PORT=ROI3, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
 # Create 3 statistics plugins with time series
-NDStatsConfigure("STATS1", $(QSIZE), 0, "ROI1", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDStatsConfigure("STATS1", $(QSIZE=20), 0, "ROI1", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
 dbLoadRecords("NDStats.template", "P=$(PREFIX), R=Stats1:, PORT=STATS1, ADDR=0, TIMEOUT=1, HIST_SIZE=256, XSIZE=$(MAX_IMAGE_WIDTH), YSIZE=$(MAX_IMAGE_HEIGHT), NCHANS=$(NCHANS=2048), NDARRAY_PORT=ROI1")
-NDTimeSeriesConfigure("STATS1_TS", $(QSIZE), 0, "STATS1", 1, 23, 0, 0, 0, 0)
+NDTimeSeriesConfigure("STATS1_TS", $(QSIZE=20), 0, "STATS1", 1, 23, 0, 0, 0, 0)
 dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template", "P=$(PREFIX), R=Stats1:TS:, PORT=STATS1_TS, ADDR=0, TIMEOUT=1, NDARRAY_PORT=STATS1, NDARRAY_ADDR=1, NCHANS=$(NCHANS=2048), ENABLED=1")
 
-NDStatsConfigure("STATS2", $(QSIZE), 0, "ROI2", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDStatsConfigure("STATS2", $(QSIZE=20), 0, "ROI2", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
 dbLoadRecords("NDStats.template", "P=$(PREFIX), R=Stats2:, PORT=STATS2, ADDR=0, TIMEOUT=1, HIST_SIZE=256, XSIZE=$(MAX_IMAGE_WIDTH), YSIZE=$(MAX_IMAGE_HEIGHT), NCHANS=$(NCHANS=2048), NDARRAY_PORT=ROI2")
-NDTimeSeriesConfigure("STATS2_TS", $(QSIZE), 0, "STATS2", 1, 23, 0, 0, 0, 0)
+NDTimeSeriesConfigure("STATS2_TS", $(QSIZE=20), 0, "STATS2", 1, 23, 0, 0, 0, 0)
 dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template", "P=$(PREFIX), R=Stats2:TS:, PORT=STATS2_TS, ADDR=0, TIMEOUT=1, NDARRAY_PORT=STATS2, NDARRAY_ADDR=1, NCHANS=$(NCHANS=2048), ENABLED=1")
 
-NDStatsConfigure("STATS3", $(QSIZE), 0, "ROI3", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDStatsConfigure("STATS3", $(QSIZE=20), 0, "ROI3", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
 dbLoadRecords("NDStats.template", "P=$(PREFIX), R=Stats3:, PORT=STATS3, ADDR=0, TIMEOUT=1, HIST_SIZE=256, XSIZE=$(MAX_IMAGE_WIDTH), YSIZE=$(MAX_IMAGE_HEIGHT), NCHANS=$(NCHANS=2048), NDARRAY_PORT=ROI3")
-NDTimeSeriesConfigure("STATS3_TS", $(QSIZE), 0, "STATS3", 1, 23, 0, 0, 0, 0)
+NDTimeSeriesConfigure("STATS3_TS", $(QSIZE=20), 0, "STATS3", 1, 23, 0, 0, 0, 0)
 dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template", "P=$(PREFIX), R=Stats3:TS:, PORT=STATS3_TS, ADDR=0, TIMEOUT=1, NDARRAY_PORT=STATS3, NDARRAY_ADDR=1, NCHANS=$(NCHANS=2048), ENABLED=1")
 
 # Create a transform plugin
-NDTransformConfigure("TRANSF1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDTransformConfigure("TRANSF1", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
 dbLoadRecords("$(ADCORE)/db/NDTransform.template", "P=$(PREFIX), R=Trans1:, PORT=TRANSF1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
 # Configure HDF5 file format plugin
-NDFileHDF5Configure("FileHDF1", $(QSIZE_HDF5), 0, "$(PORT)", 0)
+NDFileHDF5Configure("FileHDF1", $(QSIZE_HDF5=50), 0, "$(PORT)", 0)
 dbLoadRecords("NDFileHDF5.template", "P=$(PREFIX), R=HDF1:, PORT=FileHDF1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
 # Create color conversion plugin
-NDColorConvertConfigure("CC1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDColorConvertConfigure("CC1", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
 dbLoadRecords("NDColorConvert.template", "P=$(PREFIX), R=CC1:, PORT=CC1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")

--- a/iocBoot/iocCamera/st.cmd
+++ b/iocBoot/iocCamera/st.cmd
@@ -18,8 +18,6 @@ epicsEnvSet("DEVICE_VERSION", "106755-13")
 epicsEnvSet("MAX_IMAGE_WIDTH", 1280)
 epicsEnvSet("MAX_IMAGE_HEIGHT", 1024)
 epicsEnvSet("MAX_IMAGE_PIXELS", 1310720)
-epicsEnvSet("QSIZE", 20)
-epicsEnvSet("QSIZE_HDF5", 50)
 
 < plugins.cmd
 


### PR DESCRIPTION
Most camera IOCs will not require a custom queue size for plugins. Define the previously recommended values as default, that is `QSIZE=20` for all plugins but NDPluginHDF5, which takes a 50-element queue. This makes the template script shorter and easier to maintain.

This change is backward compatible with previous versions, since the variables are still used in the `plugins.cmd` template.