### PR TITLE
autosave: drop redundant ADBase requirements.

### DIFF
--- a/CameraApp/Db/camera.req
+++ b/CameraApp/Db/camera.req
@@ -1,3 +1,2 @@
-file "ADBase_settings.req",       P=$(P),     R=$(R)
 file "aravisCamera_settings.req", P=$(P),     R=$(R)
 file "NDStdArrays_settings.req",  P=$(P),     R=image1:


### PR DESCRIPTION
ADAravis autosave requirement file already includes ADGenICam requirements, which in turn depends on `ADBase_settings.req`. Drop this direct dependency on ADBase, avoiding all its PVs to become duplicated in the resulting .sav files.

Fixes: 7024f4ca3523 (autosave: configure autosave for driver and plugins.)