### PR TITLE
plugins: configure codec plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       args:
         REPONAME: ad-aravis-epics-ioc
         RUNDIR: /opt/ad-aravis-epics-ioc/iocBoot/iocCamera
-        RUNTIME_PACKAGES: libxml2 libtiff5 libaravis-0.8-0
+        RUNTIME_PACKAGES: libxml2 libtiff6 libaravis-0.8-0

--- a/iocBoot/iocCamera/device.cmd
+++ b/iocBoot/iocCamera/device.cmd
@@ -49,5 +49,8 @@ dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(PREFIX)")
 # Trace error and warning messages
 asynSetTraceMask("$(PORT)", 0, ERROR | WARNING)
 
+# Use larger callback queue to account for the high number of PVs
+callbackSetQueueSize(5000)
+
 # Configure autosave
 < autosave.cmd

--- a/iocBoot/iocCamera/plugins.cmd
+++ b/iocBoot/iocCamera/plugins.cmd
@@ -95,6 +95,10 @@ dbLoadRecords("NDROIStatN.template", "P=$(PREFIX), R=ROIStat1:3:, PORT=ROISTAT1,
 NDTransformConfigure("TRANSF1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS))
 dbLoadRecords("$(ADCORE)/db/NDTransform.template", "P=$(PREFIX), R=Trans1:, PORT=TRANSF1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
+# Create a Codec plugin
+NDCodecConfigure("CODEC1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS))
+dbLoadRecords("NDCodec.template", "P=$(PREFIX), R=Codec1:, PORT=CODEC1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
+
 # Configure HDF5 file format plugin
 NDFileHDF5Configure("FileHDF1", $(QSIZE_HDF5), 0, "$(PORT)", 0)
 dbLoadRecords("NDFileHDF5.template", "P=$(PREFIX), R=HDF1:, PORT=FileHDF1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")

--- a/iocBoot/iocCamera/plugins.cmd
+++ b/iocBoot/iocCamera/plugins.cmd
@@ -49,51 +49,56 @@
 # The maximum number of threads for plugins which can run in multiple threads.
 # Defaults to 4.
 
+epicsEnvSet("QSIZE", "$(QSIZE=20)")
+epicsEnvSet("QSIZE_HDF5", "$(QSIZE_HDF5=50)")
+epicsEnvSet("NCHANS", "$(NCHANS=2048)")
+epicsEnvSet("MAX_THREADS", "$(MAX_THREADS=4)")
+
 # Create Channel Access conversion plugin
-NDStdArraysConfigure("Image1", $(QSIZE=20), 0, $(PORT), 0, 0, 0, 0)
+NDStdArraysConfigure("Image1", $(QSIZE), 0, $(PORT), 0, 0, 0, 0)
 dbLoadRecords("NDStdArrays.template", "P=$(PREFIX), R=image1:, PORT=Image1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT), TYPE=$(IMAGE_ASYN_TYPE=Int16), FTVL=$(IMAGE_WAVEFORM_TYPE=SHORT), NELEMENTS=$(MAX_IMAGE_PIXELS)")
 
 # Create 3 ROI plugins
-NDROIConfigure("ROI1", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDROIConfigure("ROI1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS))
 dbLoadRecords("NDROI.template", "P=$(PREFIX), R=ROI1:, PORT=ROI1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
-NDROIConfigure("ROI2", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDROIConfigure("ROI2", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS))
 dbLoadRecords("NDROI.template", "P=$(PREFIX), R=ROI2:, PORT=ROI2, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
-NDROIConfigure("ROI3", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDROIConfigure("ROI3", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS))
 dbLoadRecords("NDROI.template", "P=$(PREFIX), R=ROI3:, PORT=ROI3, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
 # Create 3 statistics plugins with time series
-NDStatsConfigure("STATS1", $(QSIZE=20), 0, "ROI1", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
-dbLoadRecords("NDStats.template", "P=$(PREFIX), R=Stats1:, PORT=STATS1, ADDR=0, TIMEOUT=1, HIST_SIZE=256, XSIZE=$(MAX_IMAGE_WIDTH), YSIZE=$(MAX_IMAGE_HEIGHT), NCHANS=$(NCHANS=2048), NDARRAY_PORT=ROI1")
-NDTimeSeriesConfigure("STATS1_TS", $(QSIZE=20), 0, "STATS1", 1, 23, 0, 0, 0, 0)
-dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template", "P=$(PREFIX), R=Stats1:TS:, PORT=STATS1_TS, ADDR=0, TIMEOUT=1, NDARRAY_PORT=STATS1, NDARRAY_ADDR=1, NCHANS=$(NCHANS=2048), ENABLED=1")
+NDStatsConfigure("STATS1", $(QSIZE), 0, "ROI1", 0, 0, 0, 0, 0, $(MAX_THREADS))
+dbLoadRecords("NDStats.template", "P=$(PREFIX), R=Stats1:, PORT=STATS1, ADDR=0, TIMEOUT=1, HIST_SIZE=256, XSIZE=$(MAX_IMAGE_WIDTH), YSIZE=$(MAX_IMAGE_HEIGHT), NCHANS=$(NCHANS), NDARRAY_PORT=ROI1")
+NDTimeSeriesConfigure("STATS1_TS", $(QSIZE), 0, "STATS1", 1, 23, 0, 0, 0, 0)
+dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template", "P=$(PREFIX), R=Stats1:TS:, PORT=STATS1_TS, ADDR=0, TIMEOUT=1, NDARRAY_PORT=STATS1, NDARRAY_ADDR=1, NCHANS=$(NCHANS), ENABLED=1")
 
-NDStatsConfigure("STATS2", $(QSIZE=20), 0, "ROI2", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
-dbLoadRecords("NDStats.template", "P=$(PREFIX), R=Stats2:, PORT=STATS2, ADDR=0, TIMEOUT=1, HIST_SIZE=256, XSIZE=$(MAX_IMAGE_WIDTH), YSIZE=$(MAX_IMAGE_HEIGHT), NCHANS=$(NCHANS=2048), NDARRAY_PORT=ROI2")
-NDTimeSeriesConfigure("STATS2_TS", $(QSIZE=20), 0, "STATS2", 1, 23, 0, 0, 0, 0)
-dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template", "P=$(PREFIX), R=Stats2:TS:, PORT=STATS2_TS, ADDR=0, TIMEOUT=1, NDARRAY_PORT=STATS2, NDARRAY_ADDR=1, NCHANS=$(NCHANS=2048), ENABLED=1")
+NDStatsConfigure("STATS2", $(QSIZE), 0, "ROI2", 0, 0, 0, 0, 0, $(MAX_THREADS))
+dbLoadRecords("NDStats.template", "P=$(PREFIX), R=Stats2:, PORT=STATS2, ADDR=0, TIMEOUT=1, HIST_SIZE=256, XSIZE=$(MAX_IMAGE_WIDTH), YSIZE=$(MAX_IMAGE_HEIGHT), NCHANS=$(NCHANS), NDARRAY_PORT=ROI2")
+NDTimeSeriesConfigure("STATS2_TS", $(QSIZE), 0, "STATS2", 1, 23, 0, 0, 0, 0)
+dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template", "P=$(PREFIX), R=Stats2:TS:, PORT=STATS2_TS, ADDR=0, TIMEOUT=1, NDARRAY_PORT=STATS2, NDARRAY_ADDR=1, NCHANS=$(NCHANS), ENABLED=1")
 
-NDStatsConfigure("STATS3", $(QSIZE=20), 0, "ROI3", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
-dbLoadRecords("NDStats.template", "P=$(PREFIX), R=Stats3:, PORT=STATS3, ADDR=0, TIMEOUT=1, HIST_SIZE=256, XSIZE=$(MAX_IMAGE_WIDTH), YSIZE=$(MAX_IMAGE_HEIGHT), NCHANS=$(NCHANS=2048), NDARRAY_PORT=ROI3")
-NDTimeSeriesConfigure("STATS3_TS", $(QSIZE=20), 0, "STATS3", 1, 23, 0, 0, 0, 0)
-dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template", "P=$(PREFIX), R=Stats3:TS:, PORT=STATS3_TS, ADDR=0, TIMEOUT=1, NDARRAY_PORT=STATS3, NDARRAY_ADDR=1, NCHANS=$(NCHANS=2048), ENABLED=1")
+NDStatsConfigure("STATS3", $(QSIZE), 0, "ROI3", 0, 0, 0, 0, 0, $(MAX_THREADS))
+dbLoadRecords("NDStats.template", "P=$(PREFIX), R=Stats3:, PORT=STATS3, ADDR=0, TIMEOUT=1, HIST_SIZE=256, XSIZE=$(MAX_IMAGE_WIDTH), YSIZE=$(MAX_IMAGE_HEIGHT), NCHANS=$(NCHANS), NDARRAY_PORT=ROI3")
+NDTimeSeriesConfigure("STATS3_TS", $(QSIZE), 0, "STATS3", 1, 23, 0, 0, 0, 0)
+dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template", "P=$(PREFIX), R=Stats3:TS:, PORT=STATS3_TS, ADDR=0, TIMEOUT=1, NDARRAY_PORT=STATS3, NDARRAY_ADDR=1, NCHANS=$(NCHANS), ENABLED=1")
 
 # Create ROIStat plugin with 3 ROIs
-NDROIStatConfigure("ROISTAT1", $(QSIZE=20), 0, "$(PORT)", 0, 3, 0, 0, 0, 0, $(MAX_THREADS=4))
-dbLoadRecords("NDROIStat.template",  "P=$(PREFIX), R=ROIStat1:,   PORT=ROISTAT1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT), NCHANS=$(NCHANS=2048)")
-dbLoadRecords("NDROIStatN.template", "P=$(PREFIX), R=ROIStat1:1:, PORT=ROISTAT1, ADDR=0, TIMEOUT=1, NCHANS=$(NCHANS=2048)")
-dbLoadRecords("NDROIStatN.template", "P=$(PREFIX), R=ROIStat1:2:, PORT=ROISTAT1, ADDR=1, TIMEOUT=1, NCHANS=$(NCHANS=2048)")
-dbLoadRecords("NDROIStatN.template", "P=$(PREFIX), R=ROIStat1:3:, PORT=ROISTAT1, ADDR=2, TIMEOUT=1, NCHANS=$(NCHANS=2048)")
+NDROIStatConfigure("ROISTAT1", $(QSIZE), 0, "$(PORT)", 0, 3, 0, 0, 0, 0, $(MAX_THREADS))
+dbLoadRecords("NDROIStat.template",  "P=$(PREFIX), R=ROIStat1:,   PORT=ROISTAT1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT), NCHANS=$(NCHANS)")
+dbLoadRecords("NDROIStatN.template", "P=$(PREFIX), R=ROIStat1:1:, PORT=ROISTAT1, ADDR=0, TIMEOUT=1, NCHANS=$(NCHANS)")
+dbLoadRecords("NDROIStatN.template", "P=$(PREFIX), R=ROIStat1:2:, PORT=ROISTAT1, ADDR=1, TIMEOUT=1, NCHANS=$(NCHANS)")
+dbLoadRecords("NDROIStatN.template", "P=$(PREFIX), R=ROIStat1:3:, PORT=ROISTAT1, ADDR=2, TIMEOUT=1, NCHANS=$(NCHANS)")
 
 # Create a transform plugin
-NDTransformConfigure("TRANSF1", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDTransformConfigure("TRANSF1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS))
 dbLoadRecords("$(ADCORE)/db/NDTransform.template", "P=$(PREFIX), R=Trans1:, PORT=TRANSF1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
 # Configure HDF5 file format plugin
-NDFileHDF5Configure("FileHDF1", $(QSIZE_HDF5=50), 0, "$(PORT)", 0)
+NDFileHDF5Configure("FileHDF1", $(QSIZE_HDF5), 0, "$(PORT)", 0)
 dbLoadRecords("NDFileHDF5.template", "P=$(PREFIX), R=HDF1:, PORT=FileHDF1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
 
 # Create color conversion plugin
-NDColorConvertConfigure("CC1", $(QSIZE=20), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS=4))
+NDColorConvertConfigure("CC1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS))
 dbLoadRecords("NDColorConvert.template", "P=$(PREFIX), R=CC1:, PORT=CC1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")

--- a/iocBoot/iocCamera/plugins.cmd
+++ b/iocBoot/iocCamera/plugins.cmd
@@ -97,11 +97,11 @@ dbLoadRecords("$(ADCORE)/db/NDTransform.template", "P=$(PREFIX), R=Trans1:, PORT
 
 # Create a Codec plugin
 NDCodecConfigure("CODEC1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS))
-dbLoadRecords("NDCodec.template", "P=$(PREFIX), R=Codec1:, PORT=CODEC1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
+dbLoadRecords("NDCodec.template", "P=$(PREFIX), R=Codec1:, PORT=CODEC1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT), ENABLED=1")
 
 # Configure HDF5 file format plugin
 NDFileHDF5Configure("FileHDF1", $(QSIZE_HDF5), 0, "$(PORT)", 0)
-dbLoadRecords("NDFileHDF5.template", "P=$(PREFIX), R=HDF1:, PORT=FileHDF1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=$(PORT)")
+dbLoadRecords("NDFileHDF5.template", "P=$(PREFIX), R=HDF1:, PORT=FileHDF1, ADDR=0, TIMEOUT=1, NDARRAY_PORT=CODEC1")
 
 # Create color conversion plugin
 NDColorConvertConfigure("CC1", $(QSIZE), 0, "$(PORT)", 0, 0, 0, 0, 0, $(MAX_THREADS))

--- a/iocBoot/iocCamera/plugins.req
+++ b/iocBoot/iocCamera/plugins.req
@@ -9,5 +9,6 @@ file "NDROIStatN_settings.req",     P=$(P),  R=ROIStat1:1:
 file "NDROIStatN_settings.req",     P=$(P),  R=ROIStat1:2:
 file "NDROIStatN_settings.req",     P=$(P),  R=ROIStat1:3:
 file "NDTransform_settings.req",    P=$(P),  R=Trans1:
+file "NDCodec_settings.req",        P=$(P),  R=Codec1:
 file "NDFileHDF5_settings.req",     P=$(P),  R=HDF1:
 file "NDColorConvert_settings.req", P=$(P),  R=CC1:

--- a/iocBoot/iocCamera/post-init.cmd
+++ b/iocBoot/iocCamera/post-init.cmd
@@ -1,4 +1,22 @@
 # Post IOC initialization setup
+#
+# Optional parameters:
+#
+# $(USE_COMPRESSION)
+# Use recommended compression settings (YES or NO). Defaults to NO.
 
 create_monitor_set("ioc.req", 30, "P=$(PREFIX)")
 set_savefile_name("ioc.req", "$(PREFIX).sav")
+
+epicsEnvSet("USE_COMPRESSION", "$(USE_COMPRESSION=NO)")
+
+epicsEnvSet("CODEC_COMPRESSOR_NO", "None")
+epicsEnvSet("CODEC_COMPRESSOR_YES", "BSLZ4")
+epicsEnvSet("CODEC_NUM_THREADS_NO", 1)
+epicsEnvSet("CODEC_NUM_THREADS_YES", $(MAX_THREADS))
+
+dbpf $(PREFIX)Codec1:EnableCallbacks Enable
+dbpf $(PREFIX)Codec1:Mode Compress
+dbpf $(PREFIX)Codec1:Compressor $(CODEC_COMPRESSOR_$(USE_COMPRESSION))
+dbpf $(PREFIX)Codec1:NumThreads $(CODEC_NUM_THREADS_$(USE_COMPRESSION))
+dbpf $(PREFIX)Codec1:SortMode Sorted


### PR DESCRIPTION
Compression is an important part of the pipeline when cameras are used to save a long acquisition to disk. Using the HDF5 compression filters directly is not recommended, since it compresses using a single thread before writing to disk. Instead, the best approach is to use Codec to first compress the array, and then forward to HDF5 for direct chunk write.

Configure an instance of the codec plugin to allow such processing pipeline. To enable the best scenario with a good compression algorithm, also upgrade epics-in-docker to have bitshuffle with LZ4 available.